### PR TITLE
Change quiz to General Election 2019 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,15 @@ Manifestwho is a quiz about UK political manifestos. It's mainly supposed to be 
 
 Built in Python using Flask and a Postgres database. Deployed on Heroku at manifestwho.com. Contributions are very welcome (more details below). 
 
-## EU Election 2019 Manifesto reference
+## General Election 2019 Manifesto reference
 
-European Election 2019 manifestos used to source quotations, in alphabetical order:
+General Election 2019 manifestos used to source quotations, in alphabetical order (last accessed 1st Dec):
 
-* [Brexit party pledge card](https://twitter.com/Se[bastianEPayne/status/1125711388054364161/photo/1) 
-* [Change UK Charter for Remain](https://voteforchange.uk/wp-content/uploads/2019/05/Change-UK-Charter-for-Remain.pdf)
-* Conservative Party did not produce one so not included
-* [Green Party Manifesto](https://www.greenparty.org.uk/assets/images/national-site/eu-2019/eu-manifesto-online-19-05-07.pdf) 
-* [Labour Party Manifesto](http://labour.org.uk/wp-content/uploads/2019/05/Transforming-Britain-and-Europe-for-the-many-not-the-few.pdf)
-* [Liberal Democrat Manifesto](https://d3n8a8pro7vhmx.cloudfront.net/libdems/pages/45093/attachments/original/1557342873/Liberal_Democrat_European_Election_Manifesto_2019.pdf?1557342873)
-* [UKIP Manifesto](https://www.ukip.org/pdf/EUManifesto2019-3.pdf)
+- [Brexit Party](https://www.thebrexitparty.org/wp-content/uploads/2019/11/Contract-With-The-People.pdf)
+- [Conservative Party](https://assets-global.website-files.com/5da42e2cae7ebd3f8bde353c/5dda924905da587992a064ba_Conservative%202019%20Manifesto.pdf)
+- [Green Party](https://www.greenparty.org.uk/assets/files/Elections/Green%20Party%20Manifesto%202019.pdf)
+- [Labour Party](https://labour.org.uk/wp-content/uploads/2019/11/Real-Change-Labour-Manifesto-2019.pdf)
+- [Liberal Democrats](https://d3n8a8pro7vhmx.cloudfront.net/libdems/pages/57307/attachments/original/1574876236/Stop_Brexit_and_Build_a_Brighter_Future.pdf?1574876236)
 
 Read more about manifesto inclusion choices in the [FAQ](https://manifestwho.com/faq).
 
@@ -61,9 +59,9 @@ python3 app.py
 
 ## TODOs
 
-A few things I'd like to tackle in the future (particularly before any future election):
+A few things I'd like to tackle in the future:
 
-* Update with new manifestos, come the next UK General Election (which could be at any time!) - possibly version it to allow people to still play the EU 2019 elections version. 
+* Allow people to go back and play previous versions (EU elections 2019 version).
 * Automate testing - at the moment I'm manually testing the app as I chucked it up pretty quickly as a proof of concept; would be better to have tests that mock postgres and/or run end-to-end UI tests with Selenium or similar.
 * Add web analytics to monitor where participants are based and where referrals are coming from (e.g. if all participants were in the US, then the data won't tell us much about UK public understanding).
 * Consider additional voluntary data collection at the end e.g. voting intention. Look into the best ways of phrasing these from existing research.

--- a/app.py
+++ b/app.py
@@ -56,15 +56,19 @@ def get_quotation(session_id):
     from models import Quotation, Answer
     try:
         query=db.session.query(Answer.quotation_id).filter(Answer.session_id == session_id)
-        quotation=db.session.query(Quotation).filter(Quotation.quotation_id.notin_(query)).order_by(func.random()).first() # Get random quotation
+        quotation=db.session.query(Quotation).filter(Quotation.election == 'GE 2019').filter(Quotation.quotation_id.notin_(query)).order_by(func.random()).first() # Get random quotation
         return quotation
     except Exception as e:
         return render_template("error.html", error=str(e))
 
 def get_quotations_answered(session_id):
-    from models import Answer
+    from models import Quotation, Answer
     try:
-        answers=db.session.query(Answer.quotation_id).filter(Answer.session_id == session_id).all()
+
+        answers=db.session.query(Answer, Quotation).\
+            join(Quotation, Quotation.quotation_id==Answer.quotation_id).\
+            filter(Answer.session_id == session_id).\
+            filter(Quotation.election == 'GE 2019').all()
         return answers
     except Exception as e:
         return render_template("error.html", error=str(e))
@@ -140,7 +144,8 @@ def results():
             join(Quotation, Quotation.quotation_id==Answer.quotation_id).\
             join(guess, guess.party_id == Answer.party_id_guess).\
             join(correct, correct.party_id == Quotation.party_id).\
-            filter(Answer.session_id == session_id).all()
+            filter(Answer.session_id == session_id).\
+            filter(Quotation.election == 'GE 2019').all()
         
         answers_given_count=len(new_data)
         

--- a/static/style.css
+++ b/static/style.css
@@ -36,7 +36,7 @@ a, a:visited {
 a:hover {
   color: #FF757D;
 }
-article h2, article p{
+article h2, article p, article li{
   text-align: left;
 }
 a.play {
@@ -182,3 +182,4 @@ nav li a:hover {
     text-align: left;
     width: 100%;
   }
+}

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -7,18 +7,18 @@
     <hr>
     <h2>Why are some parties included/not included?</h2>
     <p>The parties included are cross-UK parties, which currently have sitting MPs or MEPs.</p> 
-    <p>Regional parties (e.g. SNP, Plaid Cymru, Sinn Féinn, DUP) aren't included because their regional policy focus is a bit of a give away for the quiz. The most well-known cross-UK parties currently without sitting MPs or MEPs are probably UKIP, the Women's Equality Party and the Monster Raving Loony Party.</p> 
-    <p>We needed some criteria to make sure the list wasn't too long, but am very open to feedback on whether these were the right ones.</p>
+    <p>Regional parties (e.g. SNP, Plaid Cymru, Sinn Féinn, DUP) aren't included because their regional policy focus is a bit of a give away for the quiz. The most well-known cross-UK parties currently without sitting MPs or MEPs are probably UKIP, the Women's Equality Party and the Monster Raving Loony Party. Whilst The Independent Group For Change (aka Change UK) currently have 5 sitting MPs, it is only fielding 3 candidates, all in England.</p> 
+    <p>We needed some criteria to make sure the list wasn't too long, but we're very open to feedback on whether these were the right ones.</p>
     <hr>
     <h2>Where can I read the manifestos in full?</h2>
-    <p>The manifestos used to create this quiz were the PDF versions found below (links last checked 24th Nov 2019):</p>
+    <p>The manifestos used to create this quiz were the PDF versions found below (links last checked 1st December 2019):</p>
     <ul>
       <li><a href="https://www.thebrexitparty.org/wp-content/uploads/2019/11/Contract-With-The-People.pdf">Brexit Party</a></li>
       <li><a href="https://voteforchange.uk/wp-content/uploads/2019/11/2020-Vision-The-Independent-for-Change.pdf">Change UK</a> (also known as Independents for Change)</li>
       <li><a href="https://assets-global.website-files.com/5da42e2cae7ebd3f8bde353c/5dda924905da587992a064ba_Conservative%202019%20Manifesto.pdf">Conservative Party</a></li>
       <li><a href="https://www.greenparty.org.uk/assets/files/Elections/Green%20Party%20Manifesto%202019.pdf">Green Party</a></li>
       <li><a href="https://labour.org.uk/wp-content/uploads/2019/11/Real-Change-Labour-Manifesto-2019.pdf">Labour Party</a></li>
-      <li><a href="ttps://d3n8a8pro7vhmx.cloudfront.net/libdems/pages/57307/attachments/original/1574267252/Stop_Brexit_and_Build_a_Brighter_Future.pdf?1574267252">Liberal Democrats</a></li>
+      <li><a href="https://d3n8a8pro7vhmx.cloudfront.net/libdems/pages/57307/attachments/original/1574876236/Stop_Brexit_and_Build_a_Brighter_Future.pdf?1574876236">Liberal Democrats</a></li>
     </ul>
     <hr>
     <h2>Do you store anything about me?</h2>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -2,24 +2,24 @@
 {% block body %}
   <article>
     <h1>FAQ</h1>
-    <h2>How did you choose the quotations?</h2>
-    <p><i>Coming soon.</i></p>
+    <h2>Where can I read the manifestos in full?</h2>
+    <p>The manifestos used to create this quiz were the PDF versions found below (links last checked 1st December 2019):</p>
+    <ul>
+      <li><a href="https://www.thebrexitparty.org/wp-content/uploads/2019/11/Contract-With-The-People.pdf">Brexit Party</a></li>
+      <li><a href="https://assets-global.website-files.com/5da42e2cae7ebd3f8bde353c/5dda924905da587992a064ba_Conservative%202019%20Manifesto.pdf">Conservative Party</a></li>
+      <li><a href="https://www.greenparty.org.uk/assets/files/Elections/Green%20Party%20Manifesto%202019.pdf">Green Party</a></li>
+      <li><a href="https://labour.org.uk/wp-content/uploads/2019/11/Real-Change-Labour-Manifesto-2019.pdf">Labour Party</a></li>
+      <li><a href="https://d3n8a8pro7vhmx.cloudfront.net/libdems/pages/57307/attachments/original/1574876236/Stop_Brexit_and_Build_a_Brighter_Future.pdf?1574876236">Liberal Democrats</a></li>
+    </ul>
     <hr>
     <h2>Why are some parties included/not included?</h2>
     <p>The parties included are cross-UK parties, which currently have sitting MPs or MEPs.</p> 
     <p>Regional parties (e.g. SNP, Plaid Cymru, Sinn Féinn, DUP) aren't included because their regional policy focus is a bit of a give away for the quiz. The most well-known cross-UK parties currently without sitting MPs or MEPs are probably UKIP, the Women's Equality Party and the Monster Raving Loony Party. Whilst The Independent Group For Change (aka Change UK) currently have 5 sitting MPs, it is only fielding 3 candidates, all in England.</p> 
     <p>We needed some criteria to make sure the list wasn't too long, but we're very open to feedback on whether these were the right ones.</p>
     <hr>
-    <h2>Where can I read the manifestos in full?</h2>
-    <p>The manifestos used to create this quiz were the PDF versions found below (links last checked 1st December 2019):</p>
-    <ul>
-      <li><a href="https://www.thebrexitparty.org/wp-content/uploads/2019/11/Contract-With-The-People.pdf">Brexit Party</a></li>
-      <li><a href="https://voteforchange.uk/wp-content/uploads/2019/11/2020-Vision-The-Independent-for-Change.pdf">Change UK</a> (also known as Independents for Change)</li>
-      <li><a href="https://assets-global.website-files.com/5da42e2cae7ebd3f8bde353c/5dda924905da587992a064ba_Conservative%202019%20Manifesto.pdf">Conservative Party</a></li>
-      <li><a href="https://www.greenparty.org.uk/assets/files/Elections/Green%20Party%20Manifesto%202019.pdf">Green Party</a></li>
-      <li><a href="https://labour.org.uk/wp-content/uploads/2019/11/Real-Change-Labour-Manifesto-2019.pdf">Labour Party</a></li>
-      <li><a href="https://d3n8a8pro7vhmx.cloudfront.net/libdems/pages/57307/attachments/original/1574876236/Stop_Brexit_and_Build_a_Brighter_Future.pdf?1574876236">Liberal Democrats</a></li>
-    </ul>
+    <h2>How did you choose the quotations?</h2>
+    <p>There are five quotations from each party's manifesto. They were selected according to five categories: Brexit/EU, Health, Crime, Education and Environment. These categories were based on the <a href="https://www.ipsos.com/ipsos-mori/en-uk/ipsos-mori-issues-index-september-2019-lack-faith-politics-reaches-new-high">Ipsos Mori Issues Index</a> and <a href="https://yougov.co.uk/topics/politics/articles-reports/2019/11/07/which-issues-will-decide-general-election">YouGov research into top issues for the UK public</a>. The quotations are all between 10 and 30 words long. Policies that had seen high press coverage or that go by a specific name (e.g. 'Withdrawal Agreement', 'National Education Service', 'Green New Deal') were avoided (as of 4th December 2019).</p>
+    <p>The aim of these criteria were to make the quotation selection even-handed, and the resulting quiz interesting.</p>
     <hr>
     <h2>Do you store anything about me?</h2>
     <p>No. We don't store personal data.</p>
@@ -31,5 +31,8 @@
     <hr>
     <h2>How is the quiz made?</h2>
     <p>It's a web app using Python, Flask and PostgreSQL. The code is open sourced <a href="https://github.com/JennyBrennan/manifestwho">on GitHub</a>.</p>
+    <hr>
+    <h2>When does the voting happen/when is this all over?</h2>
+    <p>The UK General Election is on Thursday 12th December. <a href="https://whocanivotefor.co.uk/">Find out who you can vote for</a> or <a href="https://wheredoivote.co.uk/">where your polling station is</a>.</p>
   </article>
 {% endblock %}

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -30,10 +30,6 @@
     <p>Nope. It's made by one politics nerd with no secret plan.</p>
     <hr>
     <h2>How is the quiz made?</h2>
-<<<<<<< HEAD
     <p>It's a web app using Python, Flask and PostgreSQL. The code is open sourced <a href="https://github.com/JennyBrennan/manifestwho">on GitHub</a>.</p>
-=======
-    <p>It's a web app using Python, Flask and PostgreSQL. The code is open sourced <a href="https://github.com/JennyBrennan/manifestwho">on GitHub</a></p>
->>>>>>> 851021907612f36d6fe9e632bc9e87915edd2bde
   </article>
 {% endblock %}

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -2,16 +2,34 @@
 {% block body %}
   <article>
     <h1>FAQ</h1>
-    <h2>Why isn't the Conservative party listed?</h2>
-    <p>The Conservative party didn't release a manifesto for the EU elections 2019 or any equivalent document. As this quiz is based on the 2019 EU manifestos, there was nothing to use for the Conservative party. It seemed a bit mean to include a button for an answer that would never be right, so we left it off.</p>
+    <h2>How did you choose the quotations?</h2>
+    <p><i>Coming soon.</i></p>
     <hr>
-    <h2>What did you use for the Brexit Party and Change UK manifestos?</h2>
-    <p>The Brexit Party published a 'Pledge Card', and Change UK published a 'Charter for Remain'. Neither of these were called manifestos by the party, but did set out their intentions for the EU elections as a centralised, national party and so seemed equivalent for use in the quiz.</p>
+    <h2>Why are some parties included/not included?</h2>
+    <p>The parties included are cross-UK parties, which currently have sitting MPs or MEPs.</p> 
+    <p>Regional parties (e.g. SNP, Plaid Cymru, Sinn Féinn, DUP) aren't included because their regional policy focus is a bit of a give away for the quiz. The most well-known cross-UK parties currently without sitting MPs or MEPs are probably UKIP, the Women's Equality Party and the Monster Raving Loony Party.</p> 
+    <p>We needed some criteria to make sure the list wasn't too long, but am very open to feedback on whether these were the right ones.</p>
+    <hr>
+    <h2>Where can I read the manifestos in full?</h2>
+    <p>The manifestos used to create this quiz were the PDF versions found below (links last checked 24th Nov 2019):</p>
+    <ul>
+      <li><a href="https://www.thebrexitparty.org/wp-content/uploads/2019/11/Contract-With-The-People.pdf">Brexit Party</a></li>
+      <li><a href="https://voteforchange.uk/wp-content/uploads/2019/11/2020-Vision-The-Independent-for-Change.pdf">Change UK</a> (also known as Independents for Change)</li>
+      <li><a href="https://assets-global.website-files.com/5da42e2cae7ebd3f8bde353c/5dda924905da587992a064ba_Conservative%202019%20Manifesto.pdf">Conservative Party</a></li>
+      <li><a href="https://www.greenparty.org.uk/assets/files/Elections/Green%20Party%20Manifesto%202019.pdf">Green Party</a></li>
+      <li><a href="https://labour.org.uk/wp-content/uploads/2019/11/Real-Change-Labour-Manifesto-2019.pdf">Labour Party</a></li>
+      <li><a href="ttps://d3n8a8pro7vhmx.cloudfront.net/libdems/pages/57307/attachments/original/1574267252/Stop_Brexit_and_Build_a_Brighter_Future.pdf?1574267252">Liberal Democrats</a></li>
+    </ul>
     <hr>
     <h2>Do you store anything about me?</h2>
-    <p>No. We don't store personal data. We do store the quiz anwers given to us with an anonymous id, and if you choose to let us know your party affiliation, we'll store that with the same anonymous id. But we have no way of tracing either back to you and we'd never want to. We're storing the results to see if we can learn something about how well understood parties' manifestos and beliefs are. If we do learn anything, we'll make it freely available.</p>
+    <p>No. We don't store personal data.</p>
+    <p>We do store the quiz anwers given to us with an anonymous id, and if you choose to let us know your party affiliation, we'll store that with the same anonymous id. But we have no way of tracing that back to you and we'd never want to. </p>
+    <p>We're storing the results to see if we can learn something about how well understood parties' manifestos and beliefs are. If we do learn anything, we'll make it freely available.</p>
+    <hr>
+    <h2>Is this site party affiliated/backed/some kind of conspiracy?</h2>
+    <p>Nope. It's made by one politics nerd with no secret plan.</p>
     <hr>
     <h2>How is the quiz made?</h2>
-    <p>It's a web app using Python, Flask and PostgreSQL.</p>
+    <p>It's a web app using Python, Flask and PostgreSQL. The code is open sourced <a href="https://github.com/JennyBrennan/manifestwho">on GitHub</a>.</p>
   </article>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% block body %}
   <h1>ManifestWho?</h1>
-  <h2>Can you guess the manifesto?</h2>
+  <h2>Can you guess the party manifesto?</h2>
   <a href="/answer" class="play">Play!</a>
+  <p>UK General Election 2019 Edition</p>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -29,9 +29,6 @@
   </main>
 
   <script>
-    // TODO: Add correct google analytics
-    // TODO: Add Cookie notification
-
     // /* Toggle between adding and removing the "responsive" class to topnav when the user clicks on the icon */
     function navToggle() {
         document.getElementsByClassName("topnav")[0].classList.toggle("responsive");

--- a/templates/question.html
+++ b/templates/question.html
@@ -3,13 +3,13 @@
     <h2>"{{ quotation.quotation }}"</h2>
     <small>Which manifesto is this from?</small>
     {% for party in parties %}
-        {% if party.party_id != 3 %}
+        {% if party.party_id != 7 %} {# Do not include UKIP. UKIP was previously an option for the EU elections quiz. #}
             <form method="POST" class="quiz">
                 <input type="hidden" name="quotation_id" value="{{ quotation.quotation_id }}">
                 <button type="submit" id="party" name="party" value="{{ party.party_id }}" class="button">{{ party.party_name }}</button>
             </form>
         {% endif %}
     {% endfor %}
-    <small>Why aren't the Conservatives listed? See our <a href="/faq">FAQ</a>.</small>
+    <small>Why are/aren't some parties listed? See our <a href="/faq">FAQ</a>.</small>
 
 {% endblock %}

--- a/templates/question.html
+++ b/templates/question.html
@@ -3,7 +3,7 @@
     <h2>"{{ quotation.quotation }}"</h2>
     <small>Which manifesto is this from?</small>
     {% for party in parties %}
-        {% if party.party_id != 7 %} {# Do not include UKIP. UKIP was previously an option for the EU elections quiz. #}
+        {% if (party.party_id != 7 and party.party_id != 2) %} {# Do not include UKIP or Change UK. These were previously options for the EU elections quiz. #}
             <form method="POST" class="quiz">
                 <input type="hidden" name="quotation_id" value="{{ quotation.quotation_id }}">
                 <button type="submit" id="party" name="party" value="{{ party.party_id }}" class="button">{{ party.party_name }}</button>


### PR DESCRIPTION
Given we're 8 days away from the 2019 General Election, this PR will enable an updated version of the quiz. The focus of this PR is getting the GE 2019 version up ASAP, and so I've not preserved the EU election quiz in this version. Future work would be to allow players to switch between the two.